### PR TITLE
[FEATURE] add logger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,8 @@
     "name": "jalameta/jps-patcher",
     "description": "Laravel patch scripts.",
     "require": {
+        "illuminate/support": "^8.0",
+        "illuminate/log": "^8.0",
         "illuminate/database": "^8.0",
         "illuminate/console": "^8.0"
     },

--- a/src/Console/PatchCommand.php
+++ b/src/Console/PatchCommand.php
@@ -3,9 +3,9 @@
 namespace Jalameta\Patcher\Console;
 
 use Illuminate\Console\ConfirmableTrait;
-use Illuminate\Database\Console\Migrations\MigrateCommand;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Database\SqlServerConnection;
+use Illuminate\Database\Console\Migrations\MigrateCommand;
 
 class PatchCommand extends MigrateCommand
 {

--- a/src/Patch.php
+++ b/src/Patch.php
@@ -23,6 +23,21 @@ abstract class Patch extends Migration
     protected $container;
 
     /**
+     * Logger.
+     *
+     * @var \Illuminate\Log\Logger
+     */
+    protected $logger;
+
+    /**
+     * Patch constructor.
+     */
+    public function __construct()
+    {
+        $this->logger = app('log')->get('patcher');
+    }
+
+    /**
      * Run patch script.
      *
      * @return void


### PR DESCRIPTION
Add custom logger specifically for patcher. with this PR, you can do this in any patch class.

```php
$this->logger->info("something useful");
```

### WHY?

Sometimes developers need to capture information within patch command into a file, with this PR, it will be stored as separate logger file located in `storage/logs/patcher.log`